### PR TITLE
Missing error icon in ON 4.2.1

### DIFF
--- a/library/src/com/andreabaccega/widget/FormEditText.java
+++ b/library/src/com/andreabaccega/widget/FormEditText.java
@@ -60,5 +60,80 @@ public class FormEditText extends EditText {
 	}
 
 	private EditTextValidator editTextValidator;
+	
+	
+	/**
+	 * Keep track of which icon we used last
+	 */
+	private Drawable lastErrorIcon = null;
+	
+	/**
+	 * Don't send delete key so edit text doesn't capture it and close error
+	 */
+	@Override
+	public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+		if (TextUtils.isEmpty(getText().toString())
+				&& keyCode == KeyEvent.KEYCODE_DEL)
+			return true;
+		else
+			return super.onKeyPreIme(keyCode, event);
+	}
+	
+	/**
+	 * Resolve an issue where the error icon is hidden under some cases in JB
+	 * due to a bug http://code.google.com/p/android/issues/detail?id=40417
+	 */
+	@Override
+	public void setError(CharSequence error, Drawable icon) {
+		super.setError(error, icon);
+		lastErrorIcon = icon;
+
+		// if the error is not null, and we are in JB, force
+		// the error to show
+		if (error != null /* !isFocused() && */) {
+			showErrorIconHax(icon);
+		}
+	}
+	
+	
+	/**
+	 * In onFocusChanged() we also have to reshow the error icon as the Editor
+	 * hides it. Because Editor is a hidden class we need to cache the last used
+	 * icon and use that
+	 */
+	@Override
+	protected void onFocusChanged(boolean focused, int direction,
+			Rect previouslyFocusedRect) {
+		super.onFocusChanged(focused, direction, previouslyFocusedRect);
+		showErrorIconHax(lastErrorIcon);
+	}
+
+/**
+	 * Use reflection to force the error icon to show. Dirty but resolves the
+	 * issue in 4.2
+	 */
+	private void showErrorIconHax(Drawable icon) {
+		if (icon == null)
+			return;
+
+		// only for JB 4.2 and 4.2.1
+		if (android.os.Build.VERSION.SDK_INT != Build.VERSION_CODES.JELLY_BEAN
+				&& android.os.Build.VERSION.SDK_INT != Build.VERSION_CODES.JELLY_BEAN_MR1)
+			return;
+
+		try {
+			Class<?> textview = Class.forName("android.widget.TextView");
+			Field tEditor = textview.getDeclaredField("mEditor");
+			tEditor.setAccessible(true);
+			Class<?> editor = Class.forName("android.widget.Editor");
+			Method privateShowError = editor.getDeclaredMethod("setErrorIcon",
+					Drawable.class);
+			privateShowError.setAccessible(true);
+			privateShowError.invoke(tEditor.get(this), icon);
+		} catch (Exception e) {
+			// e.printStackTrace(); // oh well, we tried
+		}
+	}
+	
 
 }


### PR DESCRIPTION
This is a fix for the missing error icon bug, explained in

[Android OS bug with some devices running Jelly Bean/4.2.1 - TextView.setError(CharSequence error) Missing icon](http://stackoverflow.com/q/13756978/832776)

Please note that this is fix is copied from Oleg Vaskevich and I claim no credit or responsibility.
