### PR TITLE
Fixed EmptyValidator allowing whitespace

### DIFF
--- a/library/src/com/andreabaccega/formedittextvalidator/EmptyValidator.java
+++ b/library/src/com/andreabaccega/formedittextvalidator/EmptyValidator.java
@@ -13,6 +13,6 @@ public class EmptyValidator extends Validator {
 		super(message);
 	}
 	public boolean isValid(EditText et) {
-		return ! TextUtils.isEmpty(et.getText());
+		return TextUtils.getTrimmedLength(et.getText()) > 0;
 	}
 }


### PR DESCRIPTION
If the EditText contains only whitespace then it passes validation due to checking if the field is empty. By using getTrimmedLength you can still check for the emptiness of the field, but also if they have entered only whitespace.
