### PR TITLE
Supporting a wider range of alpha characters including ñ and é.

### DIFF
--- a/library/src/com/andreabaccega/formedittextvalidator/AlphaValidator.java
+++ b/library/src/com/andreabaccega/formedittextvalidator/AlphaValidator.java
@@ -2,6 +2,6 @@ package com.andreabaccega.formedittextvalidator;
 
 public class AlphaValidator extends RegexpValidator {
 	public AlphaValidator(String message) {
-		super(message, "[a-zA-Z \\./-]*");
+		super(message, "[A-z\u00C0-\u00ff \\./-]*");
 	}
 }


### PR DESCRIPTION
This is to resolve issue #23.